### PR TITLE
Add support for kernel 4.11.0

### DIFF
--- a/drivers/TL-WN722N_v2.0-Ralink/rtl8188EUS_linux_v4.3.0.8_13968.20150417/include/osdep_service.h
+++ b/drivers/TL-WN722N_v2.0-Ralink/rtl8188EUS_linux_v4.3.0.8_13968.20150417/include/osdep_service.h
@@ -32,6 +32,10 @@
 #undef _FALSE
 #define _FALSE		0
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#endif
 
 #ifdef PLATFORM_FREEBSD
 #include <osdep_service_bsd.h>


### PR DESCRIPTION
Fixes implicit declaration of function warnings for `allow_signal`, `flush_signals` and `signal_pending`.

