### PR TITLE
Add .gitignore to ignore files generated by `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.mod
+*.mod.c
+*.o
+*.cmd
+*.ko
+.tmp_versions
+Module.symvers
+Module.markers
+modules.order


### PR DESCRIPTION
Adds a .gitignore file to hide files generated by `make` from `git status`.
