### PR TITLE
Update to conform to kernel 4.11.9

### DIFF
--- a/drivers/TL-WN722N_v2.0-Ralink/rtl8188EUS_linux_v4.3.0.8_13968.20150417/os_dep/linux/ioctl_cfg80211.c
+++ b/drivers/TL-WN722N_v2.0-Ralink/rtl8188EUS_linux_v4.3.0.8_13968.20150417/os_dep/linux/ioctl_cfg80211.c
@@ -3889,7 +3889,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
-	//mon_ndev->destructor = rtw_ndev_destructor;
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,11,9))
+	mon_ndev->needs_free_netdev = false;
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+#else
+	mon_ndev->destructor = rtw_ndev_destructor;
+#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;


### PR DESCRIPTION
struct net_device's priv_destructor replaces destructor and add needs_free_netdev on Kernel v4.11.9
ref : https://elixir.free-electrons.com/linux/v4.11.9/source/include/linux/netdevice.h